### PR TITLE
Move Client interface and Lumberjack client to their own packages.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-package main
+package client
 
 import (
 	"fmt"

--- a/file_reader.go
+++ b/file_reader.go
@@ -3,13 +3,15 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"github.com/technoweenie/grohl"
 	"io"
 	"os"
+
+	"github.com/alindeman/buttered-scones/client"
+	"github.com/technoweenie/grohl"
 )
 
 type FileData struct {
-	Data
+	client.Data
 	*HighWaterMark
 }
 
@@ -94,12 +96,12 @@ func (h *FileReader) sendChunk(chunk []*FileData) {
 	}
 }
 
-func (h *FileReader) buildDataWithLine(line []byte) Data {
-	var data Data
+func (h *FileReader) buildDataWithLine(line []byte) client.Data {
+	var data client.Data
 	if h.fields != nil {
-		data = make(Data, len(h.fields)+1)
+		data = make(client.Data, len(h.fields)+1)
 	} else {
-		data = make(Data, 2)
+		data = make(client.Data, 2)
 	}
 	data["line"] = string(line)
 	data["host"] = h.hostname

--- a/lumberjack/client_test.go
+++ b/lumberjack/client_test.go
@@ -1,8 +1,10 @@
-package main
+package lumberjack
 
 import (
 	"testing"
 	"time"
+
+	"github.com/alindeman/buttered-scones/client"
 )
 
 func TestClientSmokeTest(t *testing.T) {
@@ -19,20 +21,20 @@ func TestClientSmokeTest(t *testing.T) {
 	}
 	defer server.Close()
 
-	dataCh := make(chan Data, 1)
+	dataCh := make(chan client.Data, 1)
 	go server.ServeInto(dataCh)
 
-	client := NewLumberjackClient(&LumberjackClientOptions{
+	c := NewClient(&ClientOptions{
 		Network:           "tcp",
 		Address:           server.Addr().String(),
 		ConnectionTimeout: 2 * time.Second,
 		SendTimeout:       2 * time.Second,
 	})
 
-	lines := []Data{
-		Data{"line": "foo bar baz", "offset": "25"},
+	lines := []client.Data{
+		client.Data{"line": "foo bar baz", "offset": "25"},
 	}
-	err = client.Send(lines)
+	err = c.Send(lines)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,26 +65,26 @@ func TestClientReconnectSmokeTest(t *testing.T) {
 
 	// Without the server accepting connections, we should run into a connection
 	// timeout
-	client := NewLumberjackClient(&LumberjackClientOptions{
+	c := NewClient(&ClientOptions{
 		Network:           "tcp",
 		Address:           server.Addr().String(),
 		ConnectionTimeout: 1 * time.Second,
 		SendTimeout:       1 * time.Second,
 	})
 
-	lines := []Data{
-		Data{"line": "foo bar baz", "offset": "25"},
+	lines := []client.Data{
+		client.Data{"line": "foo bar baz", "offset": "25"},
 	}
-	err = client.Send(lines)
+	err = c.Send(lines)
 	if err == nil {
 		t.Fatalf("Expected Send to timeout, but did not")
 	}
 
 	// Now, setup the server properly, things should go through
-	dataCh := make(chan Data, 1)
+	dataCh := make(chan client.Data, 1)
 	go server.ServeInto(dataCh)
 
-	err = client.Send(lines)
+	err = c.Send(lines)
 	if err != nil {
 		t.Error(err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,12 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/boltdb/bolt"
-	"github.com/technoweenie/grohl"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/alindeman/buttered-scones/client"
+	"github.com/alindeman/buttered-scones/lumberjack"
+	"github.com/boltdb/bolt"
+	"github.com/technoweenie/grohl"
 )
 
 func main() {
@@ -29,7 +32,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	clients := make([]Client, 0, len(config.Network.Servers))
+	clients := make([]client.Client, 0, len(config.Network.Servers))
 	for _, serverName := range config.Network.Servers {
 		tlsConfig, err := config.BuildTLSConfig()
 		if err != nil {
@@ -37,7 +40,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		client := NewLumberjackClient(&LumberjackClientOptions{
+		client := lumberjack.NewClient(&lumberjack.ClientOptions{
 			Network:           "tcp",
 			Address:           serverName,
 			TLSConfig:         tlsConfig,

--- a/script/test
+++ b/script/test
@@ -4,4 +4,4 @@ set -e
 base="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 
 cd "$base"
-go test -v .
+go test -v . ./lumberjack

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/alindeman/buttered-scones/client"
 )
 
 func TestSupervisorSmokeTest(t *testing.T) {
@@ -23,10 +25,10 @@ func TestSupervisorSmokeTest(t *testing.T) {
 	files := []FileConfiguration{
 		FileConfiguration{Paths: []string{tmpFile.Name()}, Fields: map[string]string{"field1": "value1"}},
 	}
-	testClient := &TestClient{}
+	testClient := &client.TestClient{}
 	snapshotter := &MemorySnapshotter{}
 
-	supervisor := NewSupervisor(files, []Client{testClient}, snapshotter)
+	supervisor := NewSupervisor(files, []client.Client{testClient}, snapshotter)
 	supervisor.Start()
 	defer supervisor.Stop()
 


### PR DESCRIPTION
The main reason to do this is that you can use the lumberjack client outside buttered-scones. But this is also more "golang" friendly, whatever that means.
