### PR TITLE
Abstract configuration format away from treating files specially

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,7 +14,7 @@ type Configuration struct {
 	State      string                  `json:"state"`
 	Network    NetworkConfiguration    `json:"network"`
 	Statistics StatisticsConfiguration `json:"statistics"`
-	Files      []FileConfiguration     `json:"files"`
+	Inputs     []InputConfiguration    `json:"inputs"`
 	MaxLength  int                     `json:"max_length"`
 }
 
@@ -36,9 +36,12 @@ type StatisticsConfiguration struct {
 	Addr string `json:"addr"`
 }
 
-type FileConfiguration struct {
-	Paths  []string          `json:"paths"`
+type InputConfiguration struct {
+	Type   string             `json:"type"`
 	Fields map[string]string `json:"fields"`
+
+	// Fields for File inputs
+	Paths  []string          `json:"paths"`
 }
 
 func LoadConfiguration(configFile string) (*Configuration, error) {

--- a/config.json.sample
+++ b/config.json.sample
@@ -18,10 +18,11 @@
     "addr": "127.0.0.1:8088"
   },
 
-  "files": [
+  "inputs": [
     {
-      "paths":  ["/var/log/messages", "/var/log/*.log"],
-      "fields": {"type": "syslog"}
+      "type": "file",
+      "paths": ["/var/log/messages", "/var/log/*.log"],
+      "fields": { "type": "syslog" }
     }
   ]
 }

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -22,13 +22,13 @@ func TestSupervisorSmokeTest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files := []FileConfiguration{
-		FileConfiguration{Paths: []string{tmpFile.Name()}, Fields: map[string]string{"field1": "value1"}},
+	inputs := []InputConfiguration{
+		InputConfiguration{Type: "file", Paths: []string{tmpFile.Name()}, Fields: map[string]string{"field1": "value1"}},
 	}
 	testClient := &client.TestClient{}
 	snapshotter := &MemorySnapshotter{}
 
-	supervisor := NewSupervisor(files, []client.Client{testClient}, snapshotter, 0)
+	supervisor := NewSupervisor(inputs, []client.Client{testClient}, snapshotter, 0)
 	supervisor.Start()
 	defer supervisor.Stop()
 


### PR DESCRIPTION
I'm performing some work to add other input types, including TCP
and UDP. This change abstracts FileConfiguration into a general
InputConfiguration which has some common fields but also has
fields specific to a given input type. We should be able to reuse
this struct for future input types.

The tests covering the supervisor pass, but I haven't manually
tested this in the wild or anything like that.
